### PR TITLE
Allow selecting CSV templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # csv-txt-uploader
 
-Simple demo web application that compares CSV/TXT files against predefined templates,
-reports formatting issues and (optionally) uploads the data into an Oracle
-Database. It consists of a Node.js/Express backend and a minimal React UI.
+Simple demo web application that compares CSV/TXT files against predefined
+templates, reports formatting issues and (optionally) uploads the data into an
+Oracle Database. It consists of a Node.js/Express backend and a minimal React
+UI.
+
+Templates live in `server/templates` as CSV files. The first row defines the
+expected headers. When a user uploads a file, they can choose one of these CSV
+files as the template and the server will validate that the uploaded data
+matches the column structure and inferred data types from the template.


### PR DESCRIPTION
## Summary
- detect CSV templates instead of JSON
- parse the template CSV header and first row for inference
- clarify template location in README

## Testing
- `npm install` in `server`
- `node --check server/index.js`
- `node index.js` (manual run)
- `curl -s http://localhost:3000/templates`

------
https://chatgpt.com/codex/tasks/task_e_686e4f064de883339c5392c996816b3b