### PR TITLE
Add confirmation message when validation passes

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -31,7 +31,7 @@ function App() {
     } else {
       setIssues(data.issues || []);
       setDetails(data.details || {});
-      setMessage('');
+      setMessage(data.message || '');
       setShowUpload((data.issues || []).length === 0);
     }
   };

--- a/server/index.js
+++ b/server/index.js
@@ -105,7 +105,9 @@ app.post('/compare', upload.single('file'), (req, res) => {
     });
     const { issues, details } = checkData(rows, template);
     fs.unlinkSync(req.file.path);
-    res.json({ issues, details });
+    const message = issues.length === 0 ?
+      'No issues found. File matches the template.' : '';
+    res.json({ issues, details, message });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- show a confirmation string when an upload file matches the chosen template
- return that message from the compare endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e675127348333a65149d42b80544b