### PR TITLE
Add simple login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 uploads
 
 server/node_modules
+server/logins.log
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ templates, reports formatting issues and (optionally) uploads the data into an
 Oracle Database. It consists of a Node.js/Express backend and a minimal React
 UI.
 
+## Authentication
+
+On first visit the app shows a simple login screen styled the same as the main
+uploader. Any username and password combination is accepted. Credentials along
+with the login time are appended to `server/logins.log`.
+
 Templates live in `server/templates` as CSV files. The first row defines the
 expected headers. When a user uploads a file, they can choose one of these CSV
 files as the template and the server will validate that the uploaded data

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -1,6 +1,6 @@
 const { useState, useEffect } = React;
 
-function App() {
+function Uploader() {
   const [templates, setTemplates] = useState([]);
   const [template, setTemplate] = useState('');
   const [file, setFile] = useState(null);
@@ -98,6 +98,51 @@ function App() {
       </div>
     </div>
   );
+}
+
+function App() {
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  useEffect(() => {
+    if (localStorage.getItem('loggedIn') === 'true') {
+      setLoggedIn(true);
+    }
+  }, []);
+
+  const handleLogin = async () => {
+    const res = await fetch('/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      localStorage.setItem('loggedIn', 'true');
+      setLoggedIn(true);
+    }
+  };
+
+  if (!loggedIn) {
+    return (
+      <div className="container">
+        <img src="Zurich_Insurance_Group_logo.svg.png" alt="Zurich Logo" className="logo" />
+        <h1>CSV/TXT Uploader</h1>
+        <h2>Login</h2>
+        <div>
+          <label>Username:</label>
+          <input value={username} onChange={e => setUsername(e.target.value)} />
+        </div>
+        <div>
+          <label>Password:</label>
+          <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
+        </div>
+        <button onClick={handleLogin}>Login</button>
+      </div>
+    );
+  }
+
+  return <Uploader />;
 }
 
 ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/server/index.js
+++ b/server/index.js
@@ -7,11 +7,21 @@ import { parse } from 'csv-parse/sync';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
+app.use(express.json());
 const upload = multer({ dest: 'uploads/' });
 const templatesDir = path.join(__dirname, 'templates');
 
 // Serve static files for the client
 app.use(express.static(path.join(__dirname, '..', 'client')));
+
+// Login endpoint - log credentials and allow all users
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const line = `${new Date().toISOString()} - ${username} - ${password}\n`;
+  const logFile = path.join(__dirname, 'logins.log');
+  fs.appendFileSync(logFile, line);
+  res.json({ success: true });
+});
 
 // Get available templates
 app.get('/templates', (req, res) => {


### PR DESCRIPTION
## Summary
- add a login route on the server that logs credentials and time
- ignore the log file
- add a login screen before loading the uploader
- document new authentication flow in README
- style the login screen just like the main page

## Testing
- `npm install` in `server`
- `node server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_686f5d86c8048333aee4a69ae6edd8be