### PR TITLE
Fix template upload to handle table names with spaces or hyphens

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -155,14 +155,15 @@ app.post('/upload', upload.single('file'), async (req, res) => {
         .map(c => `"${c.name}" TEXT`)
         .join(', ');
 
+      const tableName = `"${template.name.replace(/"/g, '""')}"`;
       await client.query(
-        `CREATE TABLE IF NOT EXISTS ${template.name} (${createCols})`
+        `CREATE TABLE IF NOT EXISTS ${tableName} (${createCols})`
       );
 
       await client.query('BEGIN');
       for (const row of rows.slice(1)) {
         await client.query(
-          `INSERT INTO ${template.name} (${columnNames}) VALUES (${placeholders})`,
+          `INSERT INTO ${tableName} (${columnNames}) VALUES (${placeholders})`,
           row
         );
       }


### PR DESCRIPTION
## Summary
- sanitize table name with double quotes during upload queries

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `node server/index.js` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686f819ba7f48333a9361e7de4fb6bdc